### PR TITLE
change default trigger to :e

### DIFF
--- a/EmojiLauncher.qml
+++ b/EmojiLauncher.qml
@@ -7,7 +7,7 @@ QtObject {
     id: root
 
     property var pluginService: null
-    property string trigger: ":"
+    property string trigger: ":e"
 
     signal itemsChanged
 
@@ -5186,7 +5186,7 @@ QtObject {
 
     Component.onCompleted: {
         if (pluginService) {
-            trigger = pluginService.loadPluginData("emojiLauncher", "trigger", ":");
+            trigger = pluginService.loadPluginData("emojiLauncher", "trigger", ":e");
         }
         loadBundledData();
     }

--- a/plugin.json
+++ b/plugin.json
@@ -12,7 +12,7 @@
   ],
   "component": "./EmojiLauncher.qml",
   "settings": "./EmojiLauncherSettings.qml",
-  "trigger": ":",
+  "trigger": ":e",
   "permissions": [
     "settings_read",
     "settings_write"


### PR DESCRIPTION
Because of the abundance of plugins now in DMS 1.4 at least, triggers get hard to pick - I kinda like adopting the pattern of `:<letter>` for plugins,  which I did for the Sticker plugin `:s` - changing to `:e`  avoids conflicting with the sticker plugin, and maybe other plugins in the future.